### PR TITLE
Deploy Youtube Api Keys reporting tool

### DIFF
--- a/zimfarm/report/report-youtube-api-keys.cm.yaml
+++ b/zimfarm/report/report-youtube-api-keys.cm.yaml
@@ -4,7 +4,7 @@ metadata:
   name: report-youtube-api-keys
   namespace: zimfarm
 data:
-  list_youtube_api_keys_used.conf.json: |
+  report_youtube_api_keys.conf.json: |
     {
         "cc319f3e8ee3f586646b98c55bc0a7b3d9f27ac3393d1bc982aaef5930cc313a": "large-crashcourse-1",
         "9dc879afd8f9a95e7eb30167311dd7346bcc6bdfafc6bd1e217460830323c7ef": "large-mathtiques-2",

--- a/zimfarm/report/report-youtube-api-keys.cm.yaml
+++ b/zimfarm/report/report-youtube-api-keys.cm.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: report-youtube-api-keys
+  namespace: zimfarm
+data:
+  list_youtube_api_keys_used.conf.json: |
+    {
+        "cc319f3e8ee3f586646b98c55bc0a7b3d9f27ac3393d1bc982aaef5930cc313a": "large-crashcourse-1",
+        "9dc879afd8f9a95e7eb30167311dd7346bcc6bdfafc6bd1e217460830323c7ef": "large-mathtiques-2",
+        "d48ebff8fa1891f9531ab21c3bbfd0d6f1c91b301addb2bda1cea48d52531ef6": "large-sorcier-1",
+        "79e8cfc372f6fb20769a8339eb606bb17ed6a480279ff02a50f41f6cf944efd4": "large-teded-1",
+        "480e51b5ee93ee2b209906c8bf8362ddac8bd6d543f87674144ce5e66d167ebb": "large-univers-1",
+        "659fec208e08d2c8edd96a4ae7a16e71bd824c2ce569a80918fa8f4ab8e06ad7": "medium-youtubes-2",
+        "db29b7d06057fb992db99430ff19522e4781d88e2a2a2fbb2d3565296d45f722": "madrasa-playlists-2",
+        "3e2413945d668d47ab151ee1df9cb51e65360ed57c1b89eb8ee435cd47f37baf": "medium-youtubes-1",
+        "1060528e283299cc54de2f67ea9ab918b1e1ddb461b12b25eff1aba135ea458e": "small-youtubes-1",
+        "99fe8cfb95cfcf9e8851f01e567d9dd2b246a708aa7fc6b1752feb7320725c0f": "small-youtubes-2",
+        "6a0cfba941cfc1a4e85952bda5aff424cf95217d3b772777c60ec2d184112025": "madrasa-playlists-1",
+        "1c94fe405309067bd53b125f5f0c55e1640414a89e5f0075028bb313dde374eb": "large-mathtiques-1",
+        "0da9183bb0e127bb746ce77b27e1901b76c88370deeee52ec0898cb14be77c06": "unknown-1"
+    }
+
+

--- a/zimfarm/report/report-youtube-api-keys.cronjob.yaml
+++ b/zimfarm/report/report-youtube-api-keys.cronjob.yaml
@@ -13,9 +13,11 @@ spec:
       backoffLimit: 2
       template:
         spec:
+          restartPolicy: Never
           containers:
             - image: ghcr.io/openzim/zimfarm-dispatcher:latest
               imagePullPolicy: IfNotPresent
+              name: zimfarm
               envFrom:
               - secretRef:
                   name: report-youtube-api-keys
@@ -35,6 +37,7 @@ spec:
                 mountPath: /app/maint-scripts/report_youtube_api_keys.conf.json
                 subPath: report_youtube_api_keys.conf.json
                 readOnly: true
+              workingDir: /app/maint-scripts
               command: ["/app/maint-scripts/report_youtube_api_keys.py"]
               resources:
                 requests:
@@ -43,6 +46,6 @@ spec:
           volumes:
           - name: report-youtube-api-keys-config
             configMap:
-              name: report-youtube-api-keys-config
+              name: report-youtube-api-keys
           nodeSelector:
             k8s.kiwix.org/role: "services"

--- a/zimfarm/report/report-youtube-api-keys.cronjob.yaml
+++ b/zimfarm/report/report-youtube-api-keys.cronjob.yaml
@@ -25,7 +25,7 @@ spec:
               - name: GITHUB_REPO
                 value: openzim/zim-requests
               - name: GITHUB_ISSUE_ASSIGNEES
-                value: qqq
+                value: RavanJAltaie,Popolechien,benoit74
               - name: GITHUB_ISSUE_LABELS
                 value: task
               - name: CREATE_ISSUE
@@ -35,7 +35,7 @@ spec:
                 mountPath: /app/maint-scripts/report_youtube_api_keys.conf.json
                 subPath: report_youtube_api_keys.conf.json
                 readOnly: true
-              command: [/app/maint-scripts/report_youtube_api_keys.py"]
+              command: ["/app/maint-scripts/report_youtube_api_keys.py"]
               resources:
                 requests:
                   cpu: 100m

--- a/zimfarm/report/report-youtube-api-keys.cronjob.yaml
+++ b/zimfarm/report/report-youtube-api-keys.cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: report-youtube-api-keys
+  namespace: zimfarm
+spec:
+  schedule: "0 2 1 * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          containers:
+            - image: ghcr.io/openzim/zimfarm-dispatcher:latest
+              imagePullPolicy: IfNotPresent
+              envFrom:
+              - secretRef:
+                  name: report-youtube-api-keys
+              env:
+              - name: PYTHONPATH
+                value: /app
+              - name: GITHUB_REPO
+                value: openzim/zim-requests
+              - name: GITHUB_ISSUE_ASSIGNEES
+                value: qqq
+              - name: GITHUB_ISSUE_LABELS
+                value: task
+              - name: CREATE_ISSUE
+                value: "true"
+              volumeMounts:
+              - name: report-youtube-api-keys-config
+                mountPath: /app/maint-scripts/report_youtube_api_keys.conf.json
+                subPath: report_youtube_api_keys.conf.json
+                readOnly: true
+              command: [/app/maint-scripts/report_youtube_api_keys.py"]
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+          - name: report-youtube-api-keys-config
+            configMap:
+              name: report-youtube-api-keys-config
+          nodeSelector:
+            k8s.kiwix.org/role: "services"


### PR DESCRIPTION
Deploys a cronjob which will run once a month and create the report of Youtube API keys usages as a Github Issue.

What is missing:
- the secrets which are not committed:
  - POSTGRES_URI 
  - GITHUB_TOKEN: to be created under kiwix-bot?
- the final list of assignee for Github Issue (to be confirmed)