### PR TITLE
Change the Grafana Dashboard to use for weekly routine

### DIFF
--- a/.github/workflows/weekly_routine.yaml
+++ b/.github/workflows/weekly_routine.yaml
@@ -85,7 +85,7 @@ jobs:
           - [ ] Alert list is [normal](https://kiwixorg.grafana.net/alerting/list)
           - [ ] Zimfarm dashboard is [normal](https://kiwixorg.grafana.net/d/d2803d94-7c40-4338-bf80-f3cd7cd796bf/zimfarms?from=now-7d&to=now)
           - [ ] Mirrorbrain dashboard is [normal](https://kiwixorg.grafana.net/d/bb0f0990-04c5-4314-8afc-6185ac49c668/mirrorbrain?orgId=1)
-          - [ ] There is no abnormal behaviors on [cluster resources consumption](https://kiwixorg.grafana.net/d/efa86fd1d0c121a26444b636a3f509a8/kubernetes-compute-resources-cluster?orgId=1&refresh=30s&from=now-7d&to=now)
+          - [ ] There is no abnormal behaviors on [cluster resources consumption](https://kiwixorg.grafana.net/a/grafana-k8s-app/navigation/cluster/kiwix-prod)
 
           ## Projects
 


### PR DESCRIPTION
Old dashboard is not supported by Grafana anymore.

New dashboard is "the future" and more precise / concise even if not yet as feature-full (e.g. we do not have precise data on network and disk usage AFAIK)