### PR TITLE
Fix duplicate Access-Control-Allow-Origin header in OPDS endpoint

### DIFF
--- a/zim/library/frontend.yaml
+++ b/zim/library/frontend.yaml
@@ -522,9 +522,12 @@ metadata:
           return 301 "https://browse.library.kiwix.org/";
         }
 
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        
         add_header Access-Control-Allow-Origin "*" always;
 
-        # Other CORS headers
         add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
         add_header Access-Control-Allow-Credentials "true" always;


### PR DESCRIPTION
The OPDS endpoint was returning the access-control-allow-origin header twice - once from the backend (kiwix-serve) and once from nginx ingress. This caused CORS errors when clients tried to access the OPDS catalog.

Added proxy_hide_header directives to hide CORS headers from the backend before nginx adds its own headers, ensuring only one set of CORS headers is sent to clients.

Fixes #612